### PR TITLE
Support `tracing` as a feature. Update parking_lot. Fix some clippy warnings.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ readme = "README.md"
 datachannel-sys = { path = "datachannel-sys", version = "0.16.4" }
 derivative = "2"
 parking_lot = "0.12"
-tracing = "0.1"
+log = { version = "0.4", optional = true }
+tracing = { version = "0.1", optional = true }
 serde = { version = "1", features = ["derive"] }
 webrtc-sdp = "0.3"
 
@@ -26,9 +27,11 @@ async-tungstenite = { version = "0.16", features = ["tokio-runtime"] }
 crossbeam-channel = "0.5"
 futures-util = "0.3"
 tracing-subscriber = "0.3"
+env_logger = "0.9"
 serde_json = "1"
 tokio = { version = "1", features = ["rt", "macros", "time"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [features]
+default = ["log"]
 static = ["datachannel-sys/static"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,8 @@ readme = "README.md"
 [dependencies]
 datachannel-sys = { path = "datachannel-sys", version = "0.16.4" }
 derivative = "2"
-lazy_static = "1"
-log = "0.4"
-parking_lot = "0.11"
+parking_lot = "0.12"
+tracing = "0.1"
 serde = { version = "1", features = ["derive"] }
 webrtc-sdp = "0.3"
 
@@ -25,8 +24,8 @@ async-channel = "1"
 # async-tungstenite = { version = "0.14", features = ["async-std-runtime"] }
 async-tungstenite = { version = "0.16", features = ["tokio-runtime"] }
 crossbeam-channel = "0.5"
-env_logger = "0.9"
 futures-util = "0.3"
+tracing-subscriber = "0.3"
 serde_json = "1"
 tokio = { version = "1", features = ["rt", "macros", "time"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,36 +1,36 @@
 [package]
-name = "datachannel"
-version = "0.7.3"
 authors = ["Romain Leroux <romain@leroux.dev>"]
-edition = "2021"
-description = "Rust wrappers for libdatachannel."
-repository = "https://github.com/lerouxrgd/datachannel-rs"
-keywords = ["datachannel", "webrtc", "p2p"]
 categories = ["network-programming"]
+description = "Rust wrappers for libdatachannel."
+edition = "2021"
+keywords = ["datachannel", "webrtc", "p2p"]
 license = "LGPL-2.1"
+name = "datachannel"
 readme = "README.md"
+repository = "https://github.com/lerouxrgd/datachannel-rs"
+version = "0.7.3"
 
 [dependencies]
-datachannel-sys = { path = "datachannel-sys", version = "0.16.4" }
+datachannel-sys = {path = "datachannel-sys", version = "0.16.4"}
 derivative = "2"
+log = {version = "0.4", optional = true}
 parking_lot = "0.12"
-log = { version = "0.4", optional = true }
-tracing = { version = "0.1", optional = true }
-serde = { version = "1", features = ["derive"] }
+serde = {version = "1", features = ["derive"]}
+tracing = {version = "0.1", optional = true}
 webrtc-sdp = "0.3"
 
 [dev-dependencies]
 async-channel = "1"
 # async-std = { version = "1", features = ["attributes"] }
 # async-tungstenite = { version = "0.14", features = ["async-std-runtime"] }
-async-tungstenite = { version = "0.16", features = ["tokio-runtime"] }
+async-tungstenite = {version = "0.16", features = ["tokio-runtime"]}
 crossbeam-channel = "0.5"
-futures-util = "0.3"
-tracing-subscriber = "0.3"
 env_logger = "0.9"
+futures-util = "0.3"
 serde_json = "1"
-tokio = { version = "1", features = ["rt", "macros", "time"] }
-uuid = { version = "0.8", features = ["serde", "v4"] }
+tokio = {version = "1", features = ["rt", "macros", "time"]}
+tracing-subscriber = "0.3"
+uuid = {version = "0.8", features = ["serde", "v4"]}
 
 [features]
 default = ["log"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-authors = ["Romain Leroux <romain@leroux.dev>"]
-categories = ["network-programming"]
-description = "Rust wrappers for libdatachannel."
-edition = "2021"
-keywords = ["datachannel", "webrtc", "p2p"]
-license = "LGPL-2.1"
 name = "datachannel"
-readme = "README.md"
-repository = "https://github.com/lerouxrgd/datachannel-rs"
 version = "0.7.3"
+authors = ["Romain Leroux <romain@leroux.dev>"]
+edition = "2021"
+description = "Rust wrappers for libdatachannel."
+repository = "https://github.com/lerouxrgd/datachannel-rs"
+keywords = ["datachannel", "webrtc", "p2p"]
+categories = ["network-programming"]
+license = "LGPL-2.1"
+readme = "README.md"
 
 [dependencies]
-datachannel-sys = {path = "datachannel-sys", version = "0.16.4"}
+datachannel-sys = { path = "datachannel-sys", version = "0.16.4" }
 derivative = "2"
 log = {version = "0.4", optional = true}
 parking_lot = "0.12"
@@ -23,14 +23,14 @@ webrtc-sdp = "0.3"
 async-channel = "1"
 # async-std = { version = "1", features = ["attributes"] }
 # async-tungstenite = { version = "0.14", features = ["async-std-runtime"] }
-async-tungstenite = {version = "0.16", features = ["tokio-runtime"]}
+async-tungstenite = { version = "0.16", features = ["tokio-runtime"] }
 crossbeam-channel = "0.5"
 env_logger = "0.9"
 futures-util = "0.3"
 serde_json = "1"
-tokio = {version = "1", features = ["rt", "macros", "time"]}
+tokio = { version = "1", features = ["rt", "macros", "time"] }
 tracing-subscriber = "0.3"
-uuid = {version = "0.8", features = ["serde", "v4"]}
+uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [features]
 default = ["log"]

--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ Complete implementation example can be found in the [tests](tests).
 
 See also [async-datachannel][] for an async-based implementation.
 
+## Features
+
+- `log` _Default_ Enables logging provided by the `log` crate.
+- `tracing` Enables logging provided by the `tracing` crate.
+
 ## Building
 
 Note that `CMake` is required to compile [libdatachannel][] through

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,7 +28,7 @@ unsafe impl Sync for RtcConfig {}
 impl RtcConfig {
     pub fn new<S: AsRef<str>>(ice_servers: &[S]) -> Self {
         let mut ice_servers = ice_servers
-            .into_iter()
+            .iter()
             .map(|server| CString::new(server.as_ref()).unwrap())
             .collect::<Vec<_>>();
         ice_servers.shrink_to_fit();

--- a/src/datachannel.rs
+++ b/src/datachannel.rs
@@ -7,6 +7,7 @@ use std::slice;
 use datachannel_sys as sys;
 
 use crate::error::{check, Error, Result};
+use crate::logger;
 
 #[derive(Debug, Clone, Default)]
 pub struct Reliability {
@@ -221,18 +222,22 @@ where
             Ok(_) => match crate::ffi_string(&buf) {
                 Ok(label) => label,
                 Err(err) => {
-                    error!(
+                    logger::error!(
                         "Couldn't get label for RtcDataChannel id={} {:p}, {}",
-                        self.id, self, err
+                        self.id,
+                        self,
+                        err
                     );
                     String::default()
                 }
             },
 
             Err(err) => {
-                warn!(
+                logger::warn!(
                     "Couldn't get label for RtcDataChannel id={} {:p}, {}",
-                    self.id, self, err
+                    self.id,
+                    self,
+                    err
                 );
                 String::default()
             }
@@ -257,17 +262,21 @@ where
             Ok(_) => match crate::ffi_string(&buf) {
                 Ok(protocol) => Some(protocol),
                 Err(err) => {
-                    error!(
+                    logger::error!(
                         "Couldn't get protocol for RtcDataChannel id={} {:p}, {}",
-                        self.id, self, err
+                        self.id,
+                        self,
+                        err
                     );
                     None
                 }
             },
             Err(err) => {
-                warn!(
+                logger::warn!(
                     "Couldn't get protocol for RtcDataChannel id={} {:p}, {}",
-                    self.id, self, err
+                    self.id,
+                    self,
+                    err
                 );
                 None
             }
@@ -302,9 +311,11 @@ where
         match check(unsafe { sys::rtcGetBufferedAmount(self.id) }) {
             Ok(amount) => amount as usize,
             Err(err) => {
-                error!(
+                logger::error!(
                     "Couldn't get buffered_amount for RtcDataChannel id={} {:p}, {}",
-                    self.id, self, err
+                    self.id,
+                    self,
+                    err
                 );
                 0
             }
@@ -336,9 +347,11 @@ where
         match check(unsafe { sys::rtcGetAvailableAmount(self.id) }) {
             Ok(amount) => amount as usize,
             Err(err) => {
-                error!(
+                logger::error!(
                     "Couldn't get available_amount for RtcDataChannel id={} {:p}, {}",
-                    self.id, self, err
+                    self.id,
+                    self,
+                    err
                 );
                 0
             }
@@ -349,9 +362,11 @@ where
 impl<D> Drop for RtcDataChannel<D> {
     fn drop(&mut self) {
         if let Err(err) = check(unsafe { sys::rtcDeleteDataChannel(self.id) }) {
-            error!(
+            logger::error!(
                 "Error while dropping RtcDataChannel id={} {:p}: {}",
-                self.id, self, err
+                self.id,
+                self,
+                err
             );
         }
     }

--- a/src/datachannel.rs
+++ b/src/datachannel.rs
@@ -221,22 +221,18 @@ where
             Ok(_) => match crate::ffi_string(&buf) {
                 Ok(label) => label,
                 Err(err) => {
-                    tracing::error!(
+                    error!(
                         "Couldn't get label for RtcDataChannel id={} {:p}, {}",
-                        self.id,
-                        self,
-                        err
+                        self.id, self, err
                     );
                     String::default()
                 }
             },
 
             Err(err) => {
-                tracing::warn!(
+                warn!(
                     "Couldn't get label for RtcDataChannel id={} {:p}, {}",
-                    self.id,
-                    self,
-                    err
+                    self.id, self, err
                 );
                 String::default()
             }
@@ -261,21 +257,17 @@ where
             Ok(_) => match crate::ffi_string(&buf) {
                 Ok(protocol) => Some(protocol),
                 Err(err) => {
-                    tracing::error!(
+                    error!(
                         "Couldn't get protocol for RtcDataChannel id={} {:p}, {}",
-                        self.id,
-                        self,
-                        err
+                        self.id, self, err
                     );
                     None
                 }
             },
             Err(err) => {
-                tracing::warn!(
+                warn!(
                     "Couldn't get protocol for RtcDataChannel id={} {:p}, {}",
-                    self.id,
-                    self,
-                    err
+                    self.id, self, err
                 );
                 None
             }
@@ -310,11 +302,9 @@ where
         match check(unsafe { sys::rtcGetBufferedAmount(self.id) }) {
             Ok(amount) => amount as usize,
             Err(err) => {
-                tracing::error!(
+                error!(
                     "Couldn't get buffered_amount for RtcDataChannel id={} {:p}, {}",
-                    self.id,
-                    self,
-                    err
+                    self.id, self, err
                 );
                 0
             }
@@ -346,11 +336,9 @@ where
         match check(unsafe { sys::rtcGetAvailableAmount(self.id) }) {
             Ok(amount) => amount as usize,
             Err(err) => {
-                tracing::error!(
+                error!(
                     "Couldn't get available_amount for RtcDataChannel id={} {:p}, {}",
-                    self.id,
-                    self,
-                    err
+                    self.id, self, err
                 );
                 0
             }
@@ -361,11 +349,9 @@ where
 impl<D> Drop for RtcDataChannel<D> {
     fn drop(&mut self) {
         if let Err(err) = check(unsafe { sys::rtcDeleteDataChannel(self.id) }) {
-            tracing::error!(
+            error!(
                 "Error while dropping RtcDataChannel id={} {:p}: {}",
-                self.id,
-                self,
-                err
+                self.id, self, err
             );
         }
     }

--- a/src/datachannel.rs
+++ b/src/datachannel.rs
@@ -221,7 +221,7 @@ where
             Ok(_) => match crate::ffi_string(&buf) {
                 Ok(label) => label,
                 Err(err) => {
-                    log::error!(
+                    tracing::error!(
                         "Couldn't get label for RtcDataChannel id={} {:p}, {}",
                         self.id,
                         self,
@@ -232,7 +232,7 @@ where
             },
 
             Err(err) => {
-                log::warn!(
+                tracing::warn!(
                     "Couldn't get label for RtcDataChannel id={} {:p}, {}",
                     self.id,
                     self,
@@ -261,7 +261,7 @@ where
             Ok(_) => match crate::ffi_string(&buf) {
                 Ok(protocol) => Some(protocol),
                 Err(err) => {
-                    log::error!(
+                    tracing::error!(
                         "Couldn't get protocol for RtcDataChannel id={} {:p}, {}",
                         self.id,
                         self,
@@ -271,7 +271,7 @@ where
                 }
             },
             Err(err) => {
-                log::warn!(
+                tracing::warn!(
                     "Couldn't get protocol for RtcDataChannel id={} {:p}, {}",
                     self.id,
                     self,
@@ -310,7 +310,7 @@ where
         match check(unsafe { sys::rtcGetBufferedAmount(self.id) }) {
             Ok(amount) => amount as usize,
             Err(err) => {
-                log::error!(
+                tracing::error!(
                     "Couldn't get buffered_amount for RtcDataChannel id={} {:p}, {}",
                     self.id,
                     self,
@@ -346,7 +346,7 @@ where
         match check(unsafe { sys::rtcGetAvailableAmount(self.id) }) {
             Ok(amount) => amount as usize,
             Err(err) => {
-                log::error!(
+                tracing::error!(
                     "Couldn't get available_amount for RtcDataChannel id={} {:p}, {}",
                     self.id,
                     self,
@@ -360,14 +360,13 @@ where
 
 impl<D> Drop for RtcDataChannel<D> {
     fn drop(&mut self) {
-        match check(unsafe { sys::rtcDeleteDataChannel(self.id) }) {
-            Err(err) => log::error!(
+        if let Err(err) = check(unsafe { sys::rtcDeleteDataChannel(self.id) }) {
+            tracing::error!(
                 "Error while dropping RtcDataChannel id={} {:p}: {}",
                 self.id,
                 self,
                 err
-            ),
-            _ => (),
+            );
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,5 @@
 use std::sync::Once;
 
-#[cfg(feature = "tracing")]
-use tracing::Level;
-
 #[macro_use]
 mod logger;
 
@@ -57,14 +54,14 @@ fn ffi_string(ffi: &[u8]) -> crate::error::Result<String> {
 
 /// An optional function to enable libdatachannel logging via `tracing`, otherwise it will be disabled.
 #[cfg(feature = "tracing")]
-pub fn configure_logging(level: Level) {
+pub fn configure_logging(level: tracing::Level) {
     INIT_LOGGING.call_once(|| {
         let level = match level {
-            Level::ERROR => datachannel_sys::rtcLogLevel_RTC_LOG_ERROR,
-            Level::WARN => datachannel_sys::rtcLogLevel_RTC_LOG_WARNING,
-            Level::INFO => datachannel_sys::rtcLogLevel_RTC_LOG_INFO,
-            Level::DEBUG => datachannel_sys::rtcLogLevel_RTC_LOG_DEBUG,
-            Level::TRACE => datachannel_sys::rtcLogLevel_RTC_LOG_VERBOSE,
+            tracing::Level::ERROR => datachannel_sys::rtcLogLevel_RTC_LOG_ERROR,
+            tracing::Level::WARN => datachannel_sys::rtcLogLevel_RTC_LOG_WARNING,
+            tracing::Level::INFO => datachannel_sys::rtcLogLevel_RTC_LOG_INFO,
+            tracing::Level::DEBUG => datachannel_sys::rtcLogLevel_RTC_LOG_DEBUG,
+            tracing::Level::TRACE => datachannel_sys::rtcLogLevel_RTC_LOG_VERBOSE,
         };
 
         unsafe { datachannel_sys::rtcInitLogger(level, Some(sys::log_callback)) };

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,50 @@
+#[cfg(feature = "tracing")]
+macro_rules! error {
+    ($($input:tt)*) => (::tracing::error!($($input)*))
+}
+
+#[cfg(feature = "log")]
+macro_rules! error {
+    ($($input:tt)*) => (::log::error!($($input)*))
+}
+
+#[cfg(feature = "tracing")]
+#[macro_export]
+macro_rules! warn {
+    ($($input:tt)*) => (::tracing::warn!($($input)*))
+}
+
+#[cfg(feature = "log")]
+macro_rules! warn {
+    ($($input:tt)*) => (::log::warn!($($input)*))
+}
+
+#[cfg(feature = "tracing")]
+macro_rules! info {
+    ($($input:tt)*) => (::tracing::info!($($input)*))
+}
+
+#[cfg(feature = "log")]
+macro_rules! info {
+    ($($input:tt)*) => (::log::info!($($input)*))
+}
+
+#[cfg(feature = "tracing")]
+macro_rules! trace {
+    ($($input:tt)*) => (::tracing::trace!($($input)*))
+}
+
+#[cfg(feature = "log")]
+macro_rules! trace {
+    ($($input:tt)*) => (::log::trace!($($input)*))
+}
+
+#[cfg(feature = "tracing")]
+macro_rules! debug {
+    ($($input:tt)*) => (::tracing::debug!($($input)*))
+}
+
+#[cfg(feature = "log")]
+macro_rules! debug {
+    ($($input:tt)*) => (::log::debug!($($input)*))
+}

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,50 +1,20 @@
-#[cfg(feature = "tracing")]
-macro_rules! error {
-    ($($input:tt)*) => (::tracing::error!($($input)*))
-}
-
 #[cfg(feature = "log")]
-macro_rules! error {
-    ($($input:tt)*) => (::log::error!($($input)*))
-}
-
-#[cfg(feature = "tracing")]
-#[macro_export]
-macro_rules! warn {
-    ($($input:tt)*) => (::tracing::warn!($($input)*))
-}
-
+pub use log::debug;
 #[cfg(feature = "log")]
-macro_rules! warn {
-    ($($input:tt)*) => (::log::warn!($($input)*))
-}
-
-#[cfg(feature = "tracing")]
-macro_rules! info {
-    ($($input:tt)*) => (::tracing::info!($($input)*))
-}
-
+pub use log::error;
 #[cfg(feature = "log")]
-macro_rules! info {
-    ($($input:tt)*) => (::log::info!($($input)*))
-}
-
-#[cfg(feature = "tracing")]
-macro_rules! trace {
-    ($($input:tt)*) => (::tracing::trace!($($input)*))
-}
-
+pub use log::info;
 #[cfg(feature = "log")]
-macro_rules! trace {
-    ($($input:tt)*) => (::log::trace!($($input)*))
-}
-
-#[cfg(feature = "tracing")]
-macro_rules! debug {
-    ($($input:tt)*) => (::tracing::debug!($($input)*))
-}
-
+pub use log::trace;
 #[cfg(feature = "log")]
-macro_rules! debug {
-    ($($input:tt)*) => (::log::debug!($($input)*))
-}
+pub use log::warn;
+#[cfg(feature = "tracing")]
+pub use tracing::debug;
+#[cfg(feature = "tracing")]
+pub use tracing::error;
+#[cfg(feature = "tracing")]
+pub use tracing::info;
+#[cfg(feature = "tracing")]
+pub use tracing::trace;
+#[cfg(feature = "tracing")]
+pub use tracing::warn;

--- a/src/track.rs
+++ b/src/track.rs
@@ -168,11 +168,9 @@ where
 impl<T> Drop for RtcTrack<T> {
     fn drop(&mut self) {
         if let Err(err) = check(unsafe { sys::rtcDeleteTrack(self.id) }) {
-            tracing::error!(
+            error!(
                 "Error while dropping RtcTrack id={} {:p}: {}",
-                self.id,
-                self,
-                err
+                self.id, self, err
             );
         }
     }

--- a/src/track.rs
+++ b/src/track.rs
@@ -167,14 +167,13 @@ where
 
 impl<T> Drop for RtcTrack<T> {
     fn drop(&mut self) {
-        match check(unsafe { sys::rtcDeleteTrack(self.id) }) {
-            Err(err) => log::error!(
+        if let Err(err) = check(unsafe { sys::rtcDeleteTrack(self.id) }) {
+            tracing::error!(
                 "Error while dropping RtcTrack id={} {:p}: {}",
                 self.id,
                 self,
                 err
-            ),
-            _ => (),
+            );
         }
     }
 }

--- a/src/track.rs
+++ b/src/track.rs
@@ -5,6 +5,7 @@ use std::slice;
 use datachannel_sys as sys;
 
 use crate::error::{check, Result};
+use crate::logger;
 
 #[derive(Debug, Clone, Copy)]
 pub enum Direction {
@@ -168,9 +169,11 @@ where
 impl<T> Drop for RtcTrack<T> {
     fn drop(&mut self) {
         if let Err(err) = check(unsafe { sys::rtcDeleteTrack(self.id) }) {
-            error!(
+            logger::error!(
                 "Error while dropping RtcTrack id={} {:p}: {}",
-                self.id, self, err
+                self.id,
+                self,
+                err
             );
         }
     }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::env;
 use std::thread;
 use std::time::Duration;
 
@@ -9,6 +8,8 @@ use datachannel::{
     ConnectionState, DataChannelHandler, GatheringState, IceCandidate, PeerConnectionHandler,
     RtcConfig, RtcDataChannel, RtcPeerConnection, SessionDescription,
 };
+use tracing::Level;
+use tracing_subscriber::FmtSubscriber;
 
 enum ConnectionMsg {
     RemoteDescription { sess_desc: SessionDescription },
@@ -29,13 +30,13 @@ impl Ping {
 
 impl DataChannelHandler for Ping {
     fn on_open(&mut self) {
-        log::info!("DataChannel PING: Open");
+        tracing::info!("DataChannel PING: Open");
         self.ready.send(()).ok();
     }
 
     fn on_message(&mut self, msg: &[u8]) {
         let msg = String::from_utf8_lossy(msg).to_string();
-        log::info!("DataChannel PING: Received message: {}", &msg);
+        tracing::info!("DataChannel PING: Received message: {}", &msg);
         self.output.send(msg).ok();
     }
 }
@@ -54,7 +55,7 @@ impl Pong {
 impl DataChannelHandler for Pong {
     fn on_message(&mut self, msg: &[u8]) {
         let msg = String::from_utf8_lossy(msg).to_string();
-        log::info!("DataChannel PONG: Received message: {}", &msg);
+        tracing::info!("DataChannel PONG: Received message: {}", &msg);
         self.output.send(msg).ok();
     }
 }
@@ -85,29 +86,29 @@ impl PeerConnectionHandler for LocalConn {
     }
 
     fn on_description(&mut self, sess_desc: SessionDescription) {
-        log::info!("Description {}: {:?}", self.id, &sess_desc);
+        tracing::info!("Description {}: {:?}", self.id, &sess_desc);
         self.signaling
             .send(ConnectionMsg::RemoteDescription { sess_desc })
             .ok();
     }
 
     fn on_candidate(&mut self, cand: IceCandidate) {
-        log::info!("Candidate {}: {} {}", self.id, &cand.candidate, &cand.mid);
+        tracing::info!("Candidate {}: {} {}", self.id, &cand.candidate, &cand.mid);
         self.signaling
             .send(ConnectionMsg::RemoteCandidate { cand })
             .ok();
     }
 
     fn on_connection_state_change(&mut self, state: ConnectionState) {
-        log::info!("State {}: {:?}", self.id, state);
+        tracing::info!("State {}: {:?}", self.id, state);
     }
 
     fn on_gathering_state_change(&mut self, state: GatheringState) {
-        log::info!("Gathering state {}: {:?}", self.id, state);
+        tracing::info!("Gathering state {}: {:?}", self.id, state);
     }
 
     fn on_data_channel(&mut self, mut dc: Box<RtcDataChannel<Pong>>) {
-        log::info!(
+        tracing::info!(
             "PeerConnection {}: Received DataChannel with label={}, protocol={:?}, reliability={:?}",
             self.id,
             dc.label(),
@@ -121,8 +122,14 @@ impl PeerConnectionHandler for LocalConn {
 
 #[test]
 fn test_connectivity() {
-    env::set_var("RUST_LOG", "info");
-    let _ = env_logger::try_init();
+    tracing::subscriber::set_global_default(
+        FmtSubscriber::builder()
+            .with_max_level(Level::INFO)
+            .finish(),
+    )
+    .ok();
+
+    datachannel::configure_logging(Level::INFO);
 
     let (tx_res, rx_res) = chan::unbounded::<String>();
     let (tx_peer1, rx_peer1) = chan::unbounded::<ConnectionMsg>();

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -10,9 +10,9 @@ use datachannel::{
 };
 
 #[cfg(feature = "log")]
-use log::*;
+use log as logger;
 #[cfg(feature = "tracing")]
-use tracing::*;
+use tracing as logger;
 
 enum ConnectionMsg {
     RemoteDescription { sess_desc: SessionDescription },
@@ -33,13 +33,13 @@ impl Ping {
 
 impl DataChannelHandler for Ping {
     fn on_open(&mut self) {
-        info!("DataChannel PING: Open");
+        logger::info!("DataChannel PING: Open");
         self.ready.send(()).ok();
     }
 
     fn on_message(&mut self, msg: &[u8]) {
         let msg = String::from_utf8_lossy(msg).to_string();
-        info!("DataChannel PING: Received message: {}", &msg);
+        logger::info!("DataChannel PING: Received message: {}", &msg);
         self.output.send(msg).ok();
     }
 }
@@ -58,7 +58,7 @@ impl Pong {
 impl DataChannelHandler for Pong {
     fn on_message(&mut self, msg: &[u8]) {
         let msg = String::from_utf8_lossy(msg).to_string();
-        info!("DataChannel PONG: Received message: {}", &msg);
+        logger::info!("DataChannel PONG: Received message: {}", &msg);
         self.output.send(msg).ok();
     }
 }
@@ -89,29 +89,29 @@ impl PeerConnectionHandler for LocalConn {
     }
 
     fn on_description(&mut self, sess_desc: SessionDescription) {
-        info!("Description {}: {:?}", self.id, &sess_desc);
+        logger::info!("Description {}: {:?}", self.id, &sess_desc);
         self.signaling
             .send(ConnectionMsg::RemoteDescription { sess_desc })
             .ok();
     }
 
     fn on_candidate(&mut self, cand: IceCandidate) {
-        info!("Candidate {}: {} {}", self.id, &cand.candidate, &cand.mid);
+        logger::info!("Candidate {}: {} {}", self.id, &cand.candidate, &cand.mid);
         self.signaling
             .send(ConnectionMsg::RemoteCandidate { cand })
             .ok();
     }
 
     fn on_connection_state_change(&mut self, state: ConnectionState) {
-        info!("State {}: {:?}", self.id, state);
+        logger::info!("State {}: {:?}", self.id, state);
     }
 
     fn on_gathering_state_change(&mut self, state: GatheringState) {
-        info!("Gathering state {}: {:?}", self.id, state);
+        logger::info!("Gathering state {}: {:?}", self.id, state);
     }
 
     fn on_data_channel(&mut self, mut dc: Box<RtcDataChannel<Pong>>) {
-        info!(
+        logger::info!(
             "PeerConnection {}: Received DataChannel with label={}, protocol={:?}, reliability={:?}",
             self.id,
             dc.label(),

--- a/tests/websocket.rs
+++ b/tests/websocket.rs
@@ -10,9 +10,9 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 #[cfg(feature = "log")]
-use log::*;
+use log as logger;
 #[cfg(feature = "tracing")]
-use tracing::*;
+use tracing as logger;
 
 // use async_std::future::timeout;
 // use async_std::net::{TcpListener, TcpStream};
@@ -67,7 +67,7 @@ async fn handle_new_peer(peers: PeerMap, stream: TcpStream) {
         match Uuid::parse_str(tokens[1]) {
             Ok(uuid) => peer_id = Some(uuid),
             Err(err) => {
-                error!("Invalid uuid: {}", err);
+                logger::error!("Invalid uuid: {}", err);
                 *resp.status_mut() = StatusCode::BAD_REQUEST;
             }
         }
@@ -77,7 +77,7 @@ async fn handle_new_peer(peers: PeerMap, stream: TcpStream) {
     let websocket = match accept_hdr_async(stream, callback).await {
         Ok(websocket) => websocket,
         Err(err) => {
-            error!("WebSocket handshake failed: {}", err);
+            logger::error!("WebSocket handshake failed: {}", err);
             return;
         }
     };
@@ -86,7 +86,7 @@ async fn handle_new_peer(peers: PeerMap, stream: TcpStream) {
         None => return,
         Some(peer_id) => peer_id,
     };
-    info!("Peer {} connected", &peer_id);
+    logger::info!("Peer {} connected", &peer_id);
 
     let (outgoing, mut incoming) = websocket.split();
     let (tx_ws, rx_ws) = chan::unbounded();
@@ -104,22 +104,22 @@ async fn handle_new_peer(peers: PeerMap, stream: TcpStream) {
             let mut peer_msg = match serde_json::from_slice::<ConnectionMsg>(&msg.into_data()) {
                 Ok(peer_msg) => peer_msg,
                 Err(err) => {
-                    error!("Invalid ConnectionMsg: {}", err);
+                    logger::error!("Invalid ConnectionMsg: {}", err);
                     continue;
                 }
             };
-            info!("Peer {} << {:?}", &peer_id, &peer_msg);
+            logger::info!("Peer {} << {:?}", &peer_id, &peer_msg);
 
             let dest_id = peer_msg.dest_id;
 
             match peers.lock().unwrap().get_mut(&dest_id) {
                 Some(dest_peer) => {
                     peer_msg.dest_id = peer_id;
-                    info!("Peer {} >> {:?}", &dest_id, &peer_msg);
+                    logger::info!("Peer {} >> {:?}", &dest_id, &peer_msg);
                     let peer_msg = serde_json::to_vec(&peer_msg).unwrap();
                     dest_peer.try_send(Message::binary(peer_msg)).ok();
                 }
-                _ => warn!("Peer {} not found in server", &dest_id),
+                _ => logger::warn!("Peer {} not found in server", &dest_id),
             }
         }
     };
@@ -127,7 +127,7 @@ async fn handle_new_peer(peers: PeerMap, stream: TcpStream) {
     pin_mut!(dispatch, reply);
     future::select(dispatch, reply).await;
 
-    info!("Peer {} disconnected", &peer_id);
+    logger::info!("Peer {} disconnected", &peer_id);
     peers.lock().unwrap().remove(&peer_id);
 }
 
@@ -218,7 +218,7 @@ impl PeerConnectionHandler for WsConn {
     }
 
     fn on_data_channel(&mut self, mut dc: Box<RtcDataChannel<DataPipe>>) {
-        info!(
+        logger::info!(
             "Received Datachannel with: label={}, protocol={:?}, reliability={:?}",
             dc.label(),
             dc.protocol(),
@@ -252,7 +252,7 @@ async fn run_client(peer_id: Uuid, input: chan::Receiver<Uuid>, output: chan::Se
             Ok(dest_id) if dest_id != peer_id => dest_id,
             Err(_) | Ok(_) => return,
         };
-        info!("Peer {:?} sends data", &peer_id);
+        logger::info!("Peer {:?} sends data", &peer_id);
 
         let pipe = DataPipe::new_receiver(output.clone());
         let conn = WsConn::new(peer_id, dest_id, pipe, tx_ws.clone());
@@ -291,7 +291,7 @@ async fn run_client(peer_id: Uuid, input: chan::Receiver<Uuid>, output: chan::Se
             let peer_msg = match serde_json::from_slice::<ConnectionMsg>(&msg.into_data()) {
                 Ok(peer_msg) => peer_msg,
                 Err(err) => {
-                    error!("Invalid ConnectionMsg: {}", err);
+                    logger::error!("Invalid ConnectionMsg: {}", err);
                     continue;
                 }
             };
@@ -304,7 +304,7 @@ async fn run_client(peer_id: Uuid, input: chan::Receiver<Uuid>, output: chan::Se
                     MsgKind::Description(SessionDescription { sdp_type, .. })
                         if matches!(sdp_type, SdpType::Offer) =>
                     {
-                        info!("Client {:?} answering to {:?}", &peer_id, &dest_id);
+                        logger::info!("Client {:?} answering to {:?}", &peer_id, &dest_id);
 
                         let pipe = DataPipe::new_receiver(output.clone());
                         let conn = WsConn::new(peer_id, dest_id, pipe, tx_ws.clone());
@@ -314,7 +314,7 @@ async fn run_client(peer_id: Uuid, input: chan::Receiver<Uuid>, output: chan::Se
                         locked.get_mut(&dest_id).unwrap()
                     }
                     _ => {
-                        warn!("Peer {} not found in client", &dest_id);
+                        logger::warn!("Peer {} not found in client", &dest_id);
                         continue;
                     }
                 },


### PR DESCRIPTION
- Allow `tracing` or `log` based on features
- Update parking_lot to `0.12`.
- Fix some clippy warnings around patterns / matches.
- Convert tests to use `tracing-subscriber`.