### PR TITLE
Add "media" Feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 [features]
 default = ["log"]
 static = ["datachannel-sys/static"]
+media = ["datachannel-sys/media"]

--- a/datachannel-sys/Cargo.toml
+++ b/datachannel-sys/Cargo.toml
@@ -26,3 +26,4 @@ openssl-src = { version = "111.16.0", optional = true }
 
 [features]
 static = ["openssl/vendored", "openssl-src", "cpp_build"]
+media = []

--- a/datachannel-sys/build.rs
+++ b/datachannel-sys/build.rs
@@ -24,7 +24,10 @@ fn main() {
 
         config.define("NO_WEBSOCKET", "ON");
         config.define("NO_EXAMPLES", "ON");
-        config.define("NO_MEDIA", "ON");
+
+        if !cfg!(feature = "media") {
+            config.define("NO_MEDIA", "ON");
+        }
 
         config.define("OPENSSL_ROOT_DIR", get_openssl_root_dir());
         config.define("OPENSSL_USE_STATIC_LIBS", "TRUE");
@@ -36,6 +39,10 @@ fn main() {
     config.out_dir(&out_dir);
     config.define("NO_WEBSOCKET", "ON");
     config.define("NO_EXAMPLES", "ON");
+
+    if !cfg!(feature = "media") {
+        config.define("NO_MEDIA", "ON");
+    }
 
     #[cfg(not(feature = "static"))]
     {
@@ -74,6 +81,15 @@ fn main() {
             out_dir
         );
         println!("cargo:rustc-link-lib=static=usrsctp");
+
+        if cfg!(feature = "media") {
+            // Link static libsrtp
+            println!(
+                "cargo:rustc-link-search=native={}/build/deps/libsrtp",
+                out_dir
+            );
+            println!("cargo:rustc-link-lib=static=srtp2");
+        }
 
         // Link static libdatachannel
         println!("cargo:rustc-link-search=native={}/build", out_dir);


### PR DESCRIPTION
Currently, the only way to use data channel with media support enabled is to dynamically link against libdatachannel. This pull request adds a feature `media` which can be used to enable media support regardless of whether or not you're linking libdatachannel dynamically.