### PR TITLE
Minor fixes to make datachannel-rs work

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -139,8 +139,8 @@ impl Clone for RtcConfig {
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
-#[cfg_attr(not(target_os = "windows"), repr(u32))]
-#[cfg_attr(target_os = "windows", repr(i32))]
+#[cfg_attr(any(not(target_os = "windows"), target_env = "gnu"), repr(u32))]
+#[cfg_attr(all(target_os = "windows", not(target_env = "gnu")), repr(i32))]
 pub enum CertificateType {
     Default = sys::rtcCertificateType_RTC_CERTIFICATE_DEFAULT,
     ECDSA = sys::rtcCertificateType_RTC_CERTIFICATE_ECDSA,
@@ -148,8 +148,8 @@ pub enum CertificateType {
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
-#[cfg_attr(not(target_os = "windows"), repr(u32))]
-#[cfg_attr(target_os = "windows", repr(i32))]
+#[cfg_attr(any(not(target_os = "windows"), target_env = "gnu"), repr(u32))]
+#[cfg_attr(all(target_os = "windows", not(target_env = "gnu")), repr(i32))]
 pub enum TransportPolicy {
     All = sys::rtcTransportPolicy_RTC_TRANSPORT_POLICY_ALL,
     Relay = sys::rtcTransportPolicy_RTC_TRANSPORT_POLICY_RELAY,

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,11 +11,12 @@ pub struct RtcConfig {
     pub ice_servers: Vec<CString>,
     #[derivative(Debug = "ignore")]
     ice_servers_ptrs: Vec<*const c_char>,
+    pub proxy_server: Option<CString>,
     pub bind_address: Option<CString>,
     pub certificate_type: CertificateType,
     pub ice_transport_policy: TransportPolicy,
     pub enable_ice_tcp: bool,
-    // pub enable_ice_udp_mux: bool,
+    pub enable_ice_udp_mux: bool,
     pub port_range_begin: u16,
     pub port_range_end: u16,
     pub mtu: i32,
@@ -37,11 +38,12 @@ impl RtcConfig {
         RtcConfig {
             ice_servers,
             ice_servers_ptrs,
+            proxy_server: None,
             bind_address: None,
             certificate_type: CertificateType::Default,
             ice_transport_policy: TransportPolicy::All,
             enable_ice_tcp: false,
-            // enable_ice_udp_mux: false,
+            enable_ice_udp_mux: false,
             port_range_begin: 0,
             port_range_end: 0,
             mtu: 0,
@@ -99,6 +101,11 @@ impl RtcConfig {
         sys::rtcConfiguration {
             iceServers: self.ice_servers_ptrs.as_ptr() as *mut *const c_char,
             iceServersCount: self.ice_servers.len() as i32,
+            proxyServer: self
+                .proxy_server
+                .as_ref()
+                .map(|addr| addr.as_ptr())
+                .unwrap_or(ptr::null()) as *const c_char,
             bindAddress: self
                 .bind_address
                 .as_ref()
@@ -107,7 +114,7 @@ impl RtcConfig {
             certificateType: self.certificate_type as _,
             iceTransportPolicy: self.ice_transport_policy as _,
             enableIceTcp: self.enable_ice_tcp,
-            // enableIceUdpMux: self.enable_ice_udp_mux,
+            enableIceUdpMux: self.enable_ice_udp_mux,
             disableAutoNegotiation: self.disable_auto_negotiation,
             portRangeBegin: self.port_range_begin,
             portRangeEnd: self.port_range_end,
@@ -124,11 +131,12 @@ impl Clone for RtcConfig {
         RtcConfig {
             ice_servers,
             ice_servers_ptrs,
+            proxy_server: self.proxy_server.clone(),
             bind_address: self.bind_address.clone(),
             certificate_type: self.certificate_type,
             ice_transport_policy: self.ice_transport_policy,
             enable_ice_tcp: self.enable_ice_tcp,
-            // enable_ice_udp_mux: self.enable_ice_udp_mux,
+            enable_ice_udp_mux: self.enable_ice_udp_mux,
             disable_auto_negotiation: self.disable_auto_negotiation,
             port_range_begin: self.port_range_begin,
             port_range_end: self.port_range_end,

--- a/src/peerconnection.rs
+++ b/src/peerconnection.rs
@@ -147,10 +147,10 @@ impl SdpType {
 
     fn val(&self) -> &'static str {
         match self {
-            Self::Answer => "answer,",
-            Self::Offer => "offer,",
-            Self::Pranswer => "pranswer,",
-            Self::Rollback => "rollback,",
+            Self::Answer => "answer",
+            Self::Offer => "offer",
+            Self::Pranswer => "pranswer",
+            Self::Rollback => "rollback",
         }
     }
 }

--- a/src/track.rs
+++ b/src/track.rs
@@ -10,8 +10,8 @@ use crate::error::{check, Result};
 use crate::logger;
 
 #[derive(Debug, Clone, Copy)]
-#[cfg_attr(not(target_os = "windows"), repr(u32))]
-#[cfg_attr(target_os = "windows", repr(i32))]
+#[cfg_attr(any(not(target_os = "windows"), target_env = "gnu"), repr(u32))]
+#[cfg_attr(all(target_os = "windows", not(target_env = "gnu")), repr(i32))]
 pub enum Direction {
     Unknown = sys::rtcDirection_RTC_DIRECTION_UNKNOWN,
     SendOnly = sys::rtcDirection_RTC_DIRECTION_SENDONLY,
@@ -20,7 +20,7 @@ pub enum Direction {
     Inactive = sys::rtcDirection_RTC_DIRECTION_INACTIVE,
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(any(not(target_os = "windows"), target_env = "gnu"))]
 impl TryFrom<u32> for Direction {
     type Error = ();
 
@@ -36,7 +36,7 @@ impl TryFrom<u32> for Direction {
     }
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(all(target_os = "windows", not(target_env = "gnu")))]
 impl TryFrom<i32> for Direction {
     type Error = ();
 
@@ -53,8 +53,8 @@ impl TryFrom<i32> for Direction {
 }
 
 #[derive(Debug, Clone, Copy)]
-#[cfg_attr(not(target_os = "windows"), repr(u32))]
-#[cfg_attr(target_os = "windows", repr(i32))]
+#[cfg_attr(any(not(target_os = "windows"), target_env = "gnu"), repr(u32))]
+#[cfg_attr(all(target_os = "windows", not(target_env = "gnu")), repr(i32))]
 pub enum Codec {
     H264 = sys::rtcCodec_RTC_CODEC_H264,
     VP8 = sys::rtcCodec_RTC_CODEC_VP8,


### PR DESCRIPTION
- Changed enum representation on GNU/Windows to compile.
- Updated libdatachannel dependency, it doesn't work with the current version due to a missing revision of juice.
- Fixed build errors due to updated libdatachannel dependency.
- Fixed SdpType::val.