### PR TITLE
Fix unreachable code in log callback

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,9 @@ mod sys {
         let message = CStr::from_ptr(message).to_string_lossy();
         match level {
             sys::rtcLogLevel_RTC_LOG_NONE => (),
-            sys::rtcLogLevel_RTC_LOG_ERROR => logger::error!("{}", message),
+            sys::rtcLogLevel_RTC_LOG_ERROR | sys::rtcLogLevel_RTC_LOG_FATAL => {
+                logger::error!("{}", message)
+            }
             sys::rtcLogLevel_RTC_LOG_WARNING => logger::warn!("{}", message),
             sys::rtcLogLevel_RTC_LOG_INFO => logger::info!("{}", message),
             sys::rtcLogLevel_RTC_LOG_DEBUG => logger::debug!("{}", message),


### PR DESCRIPTION
The wrapper would crash if the library sent a FATAL log entry with an "entered unreachable code" panic message.
I know that FATAL logs are not commonplace but the wrapper should account for such cases.
I used `rustfmt` to format the edited code.