### PR TITLE
Export Error and Result from crate::error.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,12 @@ use std::sync::Once;
 
 mod config;
 mod datachannel;
-pub mod error;
+mod error;
 mod logger;
 mod peerconnection;
 mod track;
+
+pub use error::{Error, Result};
 
 static INIT_LOGGING: Once = Once::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use std::sync::Once;
 
 mod config;
 mod datachannel;
-mod error;
+pub mod error;
 mod logger;
 mod peerconnection;
 mod track;


### PR DESCRIPTION
There is currently no way to get the error.