### PR TITLE
Avoid slice::from_raw_parts on null pointer for zero-length messages

### DIFF
--- a/src/datachannel.rs
+++ b/src/datachannel.rs
@@ -187,6 +187,8 @@ where
         let rtc_dc = &mut *(ptr as *mut RtcDataChannel<D>);
         let msg = if size < 0 {
             CStr::from_ptr(msg).to_bytes()
+        } else if size == 0 {
+            &[]
         } else {
             slice::from_raw_parts(msg as *const u8, size as usize)
         };


### PR DESCRIPTION
When a peer sends a zero-length message, libdatachannel invokes the message callback with a null `msg` pointer and `size` of 0. `slice::from_raw_parts` requires a non-null pointer even for a zero length, so the callback panics with `unsafe precondition(s) violated` (issue #45). This returns an empty slice for the `size == 0` case instead of calling `from_raw_parts` on the null pointer.

Verified with `cargo build` against the vendored libdatachannel. A regression test would need a live peer connection exchanging an empty message, which the existing test setup does not cover, so I left the integration tests as-is.

Closes #45.